### PR TITLE
Make leaderboard better

### DIFF
--- a/commands/me.js
+++ b/commands/me.js
@@ -25,6 +25,8 @@ module.exports = {
 		if (((profileData.xpTimeoutUntil - message.createdTimestamp > 0) && (!configData.xp.xpTimeoutHidden)) || (override)) {
 			fields.push({ name: "XP Timeout", value: functions.msToString(profileData.xpTimeoutUntil - message.createdTimestamp), inline: true });
 		}
+		let xpPercentage = Math.round(profileData.xp / Math.pow(profileData.level + configData.xp.levelBaseOffset, configData.xp.levelExponent) * 100);
+		let progressBar = "█".repeat(Math.round(xpPercentage / 10)) + "░".repeat(Math.round((100 - xpPercentage) / 10));
 		const embed = new Discord.MessageEmbed()
 			.setColor("#f54242")
 			.setTitle(`Användarinfo`)
@@ -33,6 +35,7 @@ module.exports = {
 			.addFields(
 				fields,
 				{ name: "Level", value: profileData.level - 1, inline: true },
+				{ name: "Progress", value: `${progressBar} ${xpPercentage}%` },
 				{ name: "id", value: message.author.id }
 			)
 		message.channel.send(embed);

--- a/commands/memberinfo.js
+++ b/commands/memberinfo.js
@@ -41,7 +41,8 @@ module.exports = {
 		if (((profile_data.xpTimeoutUntil - message.createdTimestamp > 0) && (!configData.xp.xpTimeoutHidden)) || (override)) {
 			fields.push({ name: "XP Timeout", value: functions.msToString(profile_data.xpTimeoutUntil - message.createdTimestamp), inline: true });
 		}
-
+		let xpPercentage = Math.round(profileData.xp / Math.pow(profileData.level + configData.xp.levelBaseOffset, configData.xp.levelExponent) * 100);
+		let progressBar = "█".repeat(Math.round(xpPercentage / 10)) + "░".repeat(Math.round((100 - xpPercentage) / 10));
 		const embed = new Discord.MessageEmbed()
 			.setColor("#f54242")
 			.setTitle(`Information om medlem`)
@@ -50,6 +51,7 @@ module.exports = {
 			.addFields(
 				fields,
 				{ name: "Level", value: profile_data.level - 1, inline: true },
+				{ name: "Progress", value: `${progressBar} ${xpPercentage}%` },
 				{ name: "id", value: profile_data.userID }
 			)
 		message.channel.send(embed);

--- a/commands/xptoplist.js
+++ b/commands/xptoplist.js
@@ -22,6 +22,9 @@ module.exports = {
 
 		const profiles = await profileModel.fetchAll({ serverID: message.guild.id });
 		profiles.sort((a, b) => {
+			return b.xp - a.xp;
+		});
+		profiles.sort((a, b) => {
 			return b.level - a.level;
 		});
 

--- a/commands/xptoplist.js
+++ b/commands/xptoplist.js
@@ -38,7 +38,7 @@ module.exports = {
 		}
 
 		//Sort profiles in the right order
-		const profiles = await profileModel.fetchAll({ /*serverID: message.guild.id*/ });
+		const profiles = await profileModel.fetchAll({ serverID: message.guild.id });
 		profiles.sort((a, b) => {
 			return b.xp - a.xp;
 		});


### PR DESCRIPTION
This Pull Request fixes three issues:
- #28
- #29
- #30

It adds the functionality to cycle through different pages of the xptoplist which allows for more people showing up in the toplist. You can cycle through the pages using ⬅️ and ➡️.

I also added a simple progress bar:
![image](https://user-images.githubusercontent.com/67378443/113039887-780b6000-9198-11eb-9b27-a0766175357d.png)

The xp leaderboard now takes both XP and level into account when placing users on the toplist.