### PR TITLE
Progress bar bugfix

### DIFF
--- a/commands/me.js
+++ b/commands/me.js
@@ -25,8 +25,15 @@ module.exports = {
 		if (((profileData.xpTimeoutUntil - message.createdTimestamp > 0) && (!configData.xp.xpTimeoutHidden)) || (override)) {
 			fields.push({ name: "XP Timeout", value: functions.msToString(profileData.xpTimeoutUntil - message.createdTimestamp), inline: true });
 		}
-		let xpPercentage = Math.round(profileData.xp / Math.pow(profileData.level + configData.xp.levelBaseOffset, configData.xp.levelExponent) * 100);
+
+		let xpPercentage;
+		if (profileData.xp < 0) {
+			xpPercentage = 0;
+		} else {
+			xpPercentage = Math.round(profileData.xp / Math.pow(profileData.level + configData.xp.levelBaseOffset, configData.xp.levelExponent) * 100);
+		}
 		let progressBar = "█".repeat(Math.round(xpPercentage / 10)) + "░".repeat(Math.round((100 - xpPercentage) / 10));
+		
 		const embed = new Discord.MessageEmbed()
 			.setColor("#f54242")
 			.setTitle(`Användarinfo`)

--- a/commands/memberinfo.js
+++ b/commands/memberinfo.js
@@ -41,8 +41,15 @@ module.exports = {
 		if (((profile_data.xpTimeoutUntil - message.createdTimestamp > 0) && (!configData.xp.xpTimeoutHidden)) || (override)) {
 			fields.push({ name: "XP Timeout", value: functions.msToString(profile_data.xpTimeoutUntil - message.createdTimestamp), inline: true });
 		}
-		let xpPercentage = Math.round(profile_data.xp / Math.pow(profile_data.level + configData.xp.levelBaseOffset, configData.xp.levelExponent) * 100);
+		
+		let xpPercentage;
+		if (profileData.xp < 0) {
+			xpPercentage = 0;
+		} else {
+			xpPercentage = Math.round(profileData.xp / Math.pow(profileData.level + configData.xp.levelBaseOffset, configData.xp.levelExponent) * 100);
+		}
 		let progressBar = "█".repeat(Math.round(xpPercentage / 10)) + "░".repeat(Math.round((100 - xpPercentage) / 10));
+
 		const embed = new Discord.MessageEmbed()
 			.setColor("#f54242")
 			.setTitle(`Information om medlem`)


### PR DESCRIPTION
This PR fixes an issue where execution of memberinfo/me command would fail if the user had negative xp points. This could occur for inactive users as their XP gets subtracted by how long they've been gone when they return.

The fix checks if the user has negative XP points before trying to calculate xp percentage (which was the problem in the first place).