### PR TITLE
Hotfix for issue #49 "Users getting Trusted and other roles one (1) level to early"

### DIFF
--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -90,7 +90,7 @@ module.exports = async (message, client) => {
 				});
 				for (let index = 0; index < configData.xp.levels.length; index++) {
 					const element = configData.xp.levels[index];
-					if (profileData.level === element.level) {
+					if (profileData.level === element.level+1) { //This is the "early leveling" hotfix, we really need to fix this jungle up
 						message.member.roles.add(message.guild.roles.cache.get(element.id));
 					}
 				}


### PR DESCRIPTION
fixes #49

This is a silly hotfix for issue #49 but we really should go over this and start to make this part of the code more orderly.


